### PR TITLE
Launcher calls admin rights just for game

### DIFF
--- a/LauncherPrincipal.cs
+++ b/LauncherPrincipal.cs
@@ -208,18 +208,28 @@ namespace DDO_Launcher
 
                         if (serverResponse.Message == "Login Success")
                         {
-                            Process.Start("ddo.exe",
-                                " addr=" +
-                                ServerManager.Servers[ServerManager.SelectedServer].LobbyIP +
-                                " port=" +
-                                ServerManager.Servers[ServerManager.SelectedServer].LPort +
-                                " token=" +
-                                serverResponse.Token +
-                                " DL=http://" +
-                                ServerManager.Servers[ServerManager.SelectedServer].DLIP +
-                                ":" +
-                                ServerManager.Servers[ServerManager.SelectedServer].DLPort +
-                                "/win/ LVer=03.04.003.20181115.0 RVer=3040008");
+                            // Try to show the admin prompt to launch DDOn
+                            ProcessStartInfo pStartInfo = new ProcessStartInfo
+                            {
+                                FileName = "ddo.exe",
+
+                                Arguments = (" addr=" + 
+                                             ServerManager.Servers[ServerManager.SelectedServer].LobbyIP + 
+                                             " port=" + 
+                                             ServerManager.Servers[ServerManager.SelectedServer].LPort + 
+                                             " token=" + 
+                                             serverResponse.Token + 
+                                             " DL=http://" + 
+                                             ServerManager.Servers[ServerManager.SelectedServer].DLIP + 
+                                             ":" + 
+                                             ServerManager.Servers[ServerManager.SelectedServer].DLPort + 
+                                             "/win/ LVer=03.04.003.20181115.0 RVer=3040008"),
+
+                                Verb = "runas",
+                                UseShellExecute = true
+                            };
+
+                            Process.Start(pStartInfo);
 
                             this.Close();
                         }


### PR DESCRIPTION
Removed admin rights need for launcher by passing the value `runas` to Verb an `true` to UseShelExecute in ProcessStartInfo.