### PR TITLE
Support in mod manifests "dst" paths with extensions

### DIFF
--- a/LauncherPrincipal.cs
+++ b/LauncherPrincipal.cs
@@ -480,13 +480,26 @@ namespace DDO_Launcher
                                 ArcArchive.ArcFile dstArcFile;
                                 try
                                 {
-                                    dstArcFile = archive.GetFile(ArcArchive.Search().ByArcPath(dst));
+                                    // Split dst into full path without extension and extension if it has one
+                                    int lastDotIndex = dst.LastIndexOf('.');
+                                    string dstArcPath = dst;
+                                    string? dstExtension = null;
+                                    if (lastDotIndex != -1)
+                                    {
+                                        dstArcPath = dst.Substring(0, lastDotIndex);
+                                        dstExtension = dst.Substring(lastDotIndex + 1);
+                                    }
+                                    var search = ArcArchive.Search()
+                                        .ByArcPath(dstArcPath)
+                                        .ByExtension(dstExtension);
+                                    dstArcFile = archive.GetFile(search);
                                 }
                                 catch (Exception ex)
                                 {
-                                    throw new Exception("Couldn\'t find " + dst + " in the ARC " + arcProperty + ".\n" +
-                                                        "Make sure the path separator is an escaped backward slash (\\\\) and that the path doesn\'t include the file\'s extension\n" +
-                                                        "(e.g. \"ui\\\\00_font\\\\button_win_00_ID_HQ\" instead of \"ui/00_font/button_win_00_ID_HQ.tex\")\n\n" +
+                                    throw new Exception("Couldn\'t find or found more than one file with filename " + dst + " in the ARC " + arcProperty + ".\n\n" +
+                                                        "Make sure the path separator is an escaped backward slash (\\\\)\n" +
+                                                        "Include the destination file's extension to dissambiguate between files with the same name\n" +
+                                                        "(e.g. \"ui\\\\00_font\\\\button_win_00_ID_HQ.tex\" instead of \"ui/00_font/button_win_00_ID_HQ.tex\")\n\n" +
                                                         "Error: " + ex.Message);
                                 }
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The possible actions are:
 {
 	"action": "replace",
 	"src": "files/button_win_00_ID_HQ.tex",
-    "dst": "ui\\00_font\\button_win_00_ID_HQ"
+    "dst": "ui\\00_font\\button_win_00_ID_HQ.tex"
 }
 ```
 
@@ -79,11 +79,11 @@ The possible actions are:
 	"action": "convert",
 	"src": "files/button_win_00_ID_HQ.dds",
 	"txt": "files/button_win_00_ID_HQ.txt",
-	"dst": "ui\\00_font\\button_win_00_ID_HQ"
+	"dst": "ui\\00_font\\button_win_00_ID_HQ.tex"
 }
 ```
 
-The paths inside the ARC file MUST use escaped backward slashes (`\\`) and no extension. (e.g. `ui\\00_font\\button_win_00_ID_HQ` instead of `ui/00_font/button_win_00_ID_HQ.tex`)
+The paths inside the ARC file MUST use escaped backward slashes (`\\`). Extension is optional but **recommended**, it might be required to disambiguate files that have the same basename. (e.g. `ui\\00_font\\button_win_00_ID_HQ.tex` instead of `ui/00_font/button_win_00_ID_HQ`)
 
 #### Example manifest
 
@@ -98,7 +98,7 @@ The paths inside the ARC file MUST use escaped backward slashes (`\\`) and no ex
 				{
 					"action": "replace",
 					"src": "files/button_win_00_ID_HQ.tex",
-					"dst": "ui\\00_font\\button_win_00_ID_HQ"
+					"dst": "ui\\00_font\\button_win_00_ID_HQ.tex"
 				}
 			]
 		},
@@ -106,9 +106,10 @@ The paths inside the ARC file MUST use escaped backward slashes (`\\`) and no ex
 			"arc": "ui/gui_cmn.arc",
 			"actions": [
 				{
-					"action": "replace",
-					"src": "files/button_hud_win_00_ID_HQ.tex",
-					"dst": "ui\\00_font\\button_hud_win_00_ID_HQ"
+					"action": "convert",
+					"src": "files/button_hud_win_00_ID_HQ.dds",
+					"txt": "files/button_hud_win_00_ID_HQ.txt",
+					"dst": "ui\\00_font\\button_hud_win_00_ID_HQ.241F5DEB"
 				}
 			]
 		}


### PR DESCRIPTION
Since arc files can contain more than one file with the exact same path and file name but different JamCrc (and therefore extension), support including extensions at the end of dst paths in order to disambiguate files.

For example, an action like this would match multiple files, and therefore potentially alter the wrong file:
```json
                {
			"arc": "ui/02_map/map/field000/field000_m00_0005_0000.arc",
			"actions": [
				{
					"action": "convert",
					"src": "field000_m00_0005_0000.dds",
					"txt": "field000_m00_0005_0000.txt",
					"dst": "ui\\02_map\\map\\field000\\field000_m00_0005_0000"
				}
			]
		}
```
By adding at the end the ".tex" extension, there's only one possible file to alter:
```json
                {
			"arc": "ui/02_map/map/field000/field000_m00_0005_0000.arc",
			"actions": [
				{
					"action": "convert",
					"src": "field000_m00_0005_0000.dds",
					"txt": "field000_m00_0005_0000.txt",
					"dst": "ui\\02_map\\map\\field000\\field000_m00_0005_0000.tex"
				}
			]
		}
```